### PR TITLE
фикс кошачьих хвостов

### DIFF
--- a/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Corvax/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -86,7 +86,7 @@
           category: FacialHair
         - !type:SkinColoring
   sprites:
-    - sprite: Corvax/Mobs/Customization/cat_parts.rsi
-      state: tail_cat_wag_stripes_prime
-    - sprite: Corvax/Mobs/Customization/cat_parts.rsi
-      state: tail_cat_wag_stripes_second
+  - sprite: Corvax/Mobs/Customization/cat_parts.rsi
+    state: tail_cat_wag_stripes_prime
+  - sprite: Corvax/Mobs/Customization/cat_parts.rsi
+    state: tail_cat_wag_stripes_second


### PR DESCRIPTION
В мете вроде всё правильно было, а вот в прототипе табуляции лишние оказались. Может именно это и повлияло на отсутствие отображения в игре.