### PR TITLE
Автозамена скаф и скафа

### DIFF
--- a/Resources/Locale/ru-RU/corvax/speech/speech-chatsan.ftl
+++ b/Resources/Locale/ru-RU/corvax/speech/speech-chatsan.ftl
@@ -248,3 +248,7 @@ corvax-chatsan-word-124 = лкм
 corvax-chatsan-replacement-124 = левая рука
 corvax-chatsan-word-125 = пкм
 corvax-chatsan-replacement-125 = правая рука
+corvax-chatsan-word-126 = скаф
+corvax-chatsan-replacement-126 = скафандр
+corvax-chatsan-word-127 = скафа
+corvax-chatsan-replacement-127 = скафандра

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -696,6 +696,9 @@
     corvax-chatsan-word-123: corvax-chatsan-replacement-123
     corvax-chatsan-word-124: corvax-chatsan-replacement-124
     corvax-chatsan-word-125: corvax-chatsan-replacement-125
+    corvax-chatsan-word-126: corvax-chatsan-replacement-126
+    corvax-chatsan-word-127: corvax-chatsan-replacement-127
+# 126 and 127 are responsible for translating from "скаф" and "скафа" to "скафандр" and "скафандра" 
 # Corvax-ChatSanitize-End
 
 - type: accent


### PR DESCRIPTION
Я добавил автозамену сокращений
1. скаф
2. скафа
Соответственно на
1. скафандр
2. скафандра
Всё это добавил в автозамену корвакса, так как для своей нужно запариться, что как по мне не имеет смысла. Где можно - закомментировал.

- Протестировано и проверено. Всё работает исправно
:adv_cl: Добавлена автозамена сокращения "скаф" и "скафа"
