### PR TITLE
Фикс целей у мидраунд антагов

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -37,7 +37,6 @@
     - id: SleeperAgents
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
-    - id: DerelictCyborgSpawn
 
 - type: entity
   id: BaseStationEvent


### PR DESCRIPTION
Починил отсутствие целей у гост антагов и слиперов