### PR TITLE
fix

### DIFF
--- a/Content.Server/Chat/Managers/ChatSanitizationManager.cs
+++ b/Content.Server/Chat/Managers/ChatSanitizationManager.cs
@@ -26,7 +26,7 @@ public sealed class ChatSanitizationManager : IChatSanitizationManager
         { "рофл", "chatsan-laughs" },
         { "яхз", "chatsan-shrugs" },
         { ":0", "chatsan-surprised" },
-        { ":р", "chatsan-stick-out-tongue" }, // cyrillic р
+        { ";р", "chatsan-stick-out-tongue" }, // cyrillic р
         { "кек", "chatsan-laughs" },
         { "T_T", "chatsan-cries" },
         { "Т_Т", "chatsan-cries" }, // cyrillic T


### PR DESCRIPTION
_В игре существует комбинация символов ("`:р`"), которая активирует главный канал рации. Например, ученый начнет говорить в научный канал, а грузчик — в канал снабжения и т.д. Однако, из-за того, что комбинация "`:р`" также используется для выражения эмоции "показать язык", отправка сообщений в главный канал с её помощью становилась невозможной_
## Описание PR
Комбинация символов для вызова эмоции "показать язык" была изменена из-за вышеуказанной проблемы. Теперь вместо "`:р`" необходимо использовать "`;р`" (Естественно, речь идет именно о кириллических символах).

## Медиа
![{DBC4B7CD-F2EB-48E2-8385-08D1BF32665E}](https://github.com/user-attachments/assets/eb563765-3ef2-4201-aa92-06e4e5fc06a6)

**Проверки**
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.

## Изменения
:cl:
- fix: Теперь главный канал рации, активируемый комбинацией символов ":р", снова функционирует.
- tweak: Теперь, чтобы показать язык, используйте ";р" вместо привычного ":р".