### PR TITLE
мозг боргов

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -455,7 +455,7 @@
   - type: ContainerFill
     containers:
       borg_brain:
-        - MMIFilled
+        - PositronicBrain # Adventure
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
1. мозг боргов заменён на позитронный (так как его можно отключить, если игрок выйдет ссд, позитрон можно перезапустить для госта)