### PR TITLE
Азотодышащим

### DIFF
--- a/Resources/Prototypes/Adventure/Races/Vox/Vox_organs.yml
+++ b/Resources/Prototypes/Adventure/Races/Vox/Vox_organs.yml
@@ -1,0 +1,18 @@
+- type: entity
+  id: OrganVoxHeart
+  parent: OrganHumanHeart
+  name: сердце вокса
+  description: Мне жаль бессердечного ублюдка, который потерял это.
+  components:
+  - type: Sprite
+    state: heart-on
+  - type: Metabolizer
+    maxReagents: 2
+    metabolizerTypes: [Vox]
+    groups:
+    - id: Medicine
+    - id: Poison
+    - id: Narcotic
+  - type: Item
+    size: Small
+    heldPrefix: heart

--- a/Resources/Prototypes/Adventure/Reagents/Nitroxalin.yml
+++ b/Resources/Prototypes/Adventure/Reagents/Nitroxalin.yml
@@ -1,0 +1,55 @@
+- type: reagent
+  id: Nitroxalin
+  name: Нитроксалин
+  group: Medicine
+  desc: Необходим для восстановления уровня азота в крови.
+  physicalDesc: бесцветное
+  flavor: medicine
+  color: "#cbece2"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        conditions: 
+        - !type:OrganType 
+          type: Vox
+          shouldHave: true
+        damage:
+          types:
+            Asphyxiation: -3.5
+      - !type:HealthChange
+        conditions: 
+        - !type:OrganType 
+          type: Zerah
+          shouldHave: true
+        damage:
+          types:
+            Asphyxiation: -3.5
+      - !type:HealthChange
+        conditions: 
+        - !type:OrganType 
+          type: Slime
+          shouldHave: true
+        damage:
+          types:
+            Asphyxiation: -3.5
+      - !type:HealthChange
+        conditions:
+          - !type:ReagentThreshold
+            min: 20
+        damage:
+          types:
+            Asphyxiation: 3
+            Cold: 1
+
+- type: reaction
+  id: Nitroxalin
+  minTemp: 320
+  reactants:
+    Nitrogen:
+      amount: 2
+    Plasma:
+      amount: 1
+      catalyst: true
+  products:
+    Nitroxalin: 3

--- a/Resources/Prototypes/Body/Prototypes/vox.yml
+++ b/Resources/Prototypes/Body/Prototypes/vox.yml
@@ -18,7 +18,7 @@
       - right leg
       - left leg
       organs:
-        heart: OrganHumanHeart
+        heart: OrganVoxHeart # Adventure
         lungs: OrganVoxLungs
         stomach: OrganHumanStomach
         liver: OrganHumanLiver

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -260,6 +260,26 @@
           types:
             Asphyxiation: -1
             Bloodloss: -0.5
+# Adventure-start
+        conditions: 
+        - !type:OrganType 
+          type: Vox
+          shouldHave: false
+        - !type:OrganType 
+          type: Zerah
+          shouldHave: false
+        - !type:OrganType 
+          type: Slime
+          shouldHave: false
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 3
+        conditions: 
+        - !type:OrganType 
+          type: Vox
+          shouldHave: true
+# Adventure-start
       - !type:HealthChange
         conditions:
           - !type:ReagentThreshold
@@ -285,6 +305,26 @@
           types:
             Asphyxiation: -3.5
             Bloodloss: -3
+# Adventure-start
+        conditions: 
+        - !type:OrganType 
+          type: Vox
+          shouldHave: false
+        - !type:OrganType 
+          type: Zerah
+          shouldHave: false
+        - !type:OrganType 
+          type: Slime
+          shouldHave: false
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 1
+        conditions: 
+        - !type:OrganType 
+          type: Vox
+          shouldHave: true
+# Adventure-start
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
1. дексалин и дексалин+ больше не лечат зерах, воксов и слаймов
2. дексалин и дексалин+ теперь наносят воксам небольшой урон ядом
3. добавлен азотный аналог дексалина+ для лечения удушения зерах, воксов и слаймов