### PR TITLE
Добавил мосинке возможность бить в ближнем бою штыком

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -46,6 +46,16 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+  - type: Gun # /. Эта часть прототипа(включительно эту строчку и ниже, по конец комента) отвечает за то, чтобы мосинка могла бить.
+    useKey: false
+  - type: MeleeWeapon
+    attackRate: 0.75
+    wideAnimationRotation: -135
+    damage:
+     types:
+       Piercing: 5
+       Slash: 10
+  - type: GunRequiresWield # \ Конец комента, чтобы не ебаться с апстримом, <3
 
 - type: entity
   name: Hristov


### PR DESCRIPTION
По урону: 10 порезов и 5 уколов, скорость атаки - 0.75
Теперь мосинка стреляет с двух рук. Если держать её в одной, то на пкм она будет бить с размахом, а на лкм точно. 
Если взять в две руки, то на лкм будет бить без размаха, а на пкм стрелять
Вот ссылка на видос https://youtu.be/sWQ4kirdBos (мб ещё не загрузился, через 10 минут чекните.)