### PR TITLE
Исправление карт

### DIFF
--- a/Resources/Maps/Adventure/Adventureamber.yml
+++ b/Resources/Maps/Adventure/Adventureamber.yml
@@ -47,6 +47,19 @@ tilemap:
 entities:
 - proto: ""
   entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Amber
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+    - type: LoadedMap
   - uid: 2
     components:
     - type: MetaData
@@ -55314,13 +55327,6 @@ entities:
     - type: Transform
       pos: -17.5,-57.5
       parent: 2
-- proto: HatChefNPCMouseRemy
-  entities:
-  - uid: 20476
-    components:
-    - type: Transform
-      pos: -8.760822,-30.469727
-      parent: 2
 - proto: CrateSecurityTrackingMindshieldImplants
   entities:
   - uid: 4184
@@ -65623,7 +65629,7 @@ entities:
       pos: -16.5,-17.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -33846.67
+      secondsUntilStateChange: -33921.574
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -93326,6 +93332,13 @@ entities:
     - type: Transform
       pos: 17.714645,15.530955
       parent: 2
+- proto: HatChefNPCMouseRemy
+  entities:
+  - uid: 20476
+    components:
+    - type: Transform
+      pos: -8.760822,-30.469727
+      parent: 2
 - proto: HeatExchanger
   entities:
   - uid: 2550
@@ -93389,7 +93402,7 @@ entities:
       parent: 2
 - proto: HolopadAiCore
   entities:
-  - uid: 1
+  - uid: 20475
     components:
     - type: Transform
       pos: -65.5,-11.5
@@ -97106,6 +97119,7 @@ entities:
 
         ===================================================
     - type: Contraband
+      allowedJobs: []
       allowedDepartments:
       - Security
       severity: Syndicate

--- a/Resources/Maps/Adventure/Adventurecluster.yml
+++ b/Resources/Maps/Adventure/Adventurecluster.yml
@@ -45,6 +45,19 @@ tilemap:
 entities:
 - proto: ""
   entities:
+  - uid: 12679
+    components:
+    - type: MetaData
+      name: Cluster
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+    - type: LoadedMap
   - uid: 1
     components:
     - type: MetaData

--- a/Resources/Maps/Adventure/Adventureloop.yml
+++ b/Resources/Maps/Adventure/Adventureloop.yml
@@ -35,6 +35,19 @@ tilemap:
 entities:
 - proto: ""
   entities:
+  - uid: 13915
+    components:
+    - type: MetaData
+      name: Loop
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+    - type: LoadedMap
   - uid: 2
     components:
     - type: MetaData

--- a/Resources/Maps/Adventure/Adventuremarathon.yml
+++ b/Resources/Maps/Adventure/Adventuremarathon.yml
@@ -65,6 +65,19 @@ tilemap:
 entities:
 - proto: ""
   entities:
+  - uid: 22632
+    components:
+    - type: MetaData
+      name: Marathon
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+    - type: LoadedMap
   - uid: 30
     components:
     - type: MetaData


### PR DESCRIPTION
У четырёх карт (AdventureAmber, AdventureCluster, AdventureLoop и AdventureMarathon) отсутствовала основная метадата, из-за чего их нельзя было зарендерить. Я исправил это.