### PR TITLE
Теперь энергоядра НТ дают по 50 секунд работы за одну моль фрезона.

### DIFF
--- a/Resources/Prototypes/Adventure/EnergyCores/bigcores.yml
+++ b/Resources/Prototypes/Adventure/EnergyCores/bigcores.yml
@@ -57,7 +57,7 @@
     timeOfLife: 600
     enablingLenght: 7.7
     baseSupply: 300000
-    secPerMoles: 0.375
+    secPerMoles: 50
   - type: PowerSupplier
     supplyRate: 300000
   - type: Sprite

--- a/Resources/Prototypes/Adventure/EnergyCores/mediumcores.yml
+++ b/Resources/Prototypes/Adventure/EnergyCores/mediumcores.yml
@@ -60,7 +60,7 @@
     timeOfLife: 600
     enablingLenght: 7.7
     baseSupply: 200000
-    secPerMoles: 0.75
+    secPerMoles: 50
   - type: PowerSupplier
     supplyRate: 200000
   - type: Sprite

--- a/Resources/Prototypes/Adventure/EnergyCores/smallcores.yml
+++ b/Resources/Prototypes/Adventure/EnergyCores/smallcores.yml
@@ -60,7 +60,7 @@
     timeOfLife: 600
     enablingLenght: 7.7
     baseSupply: 80000
-    secPerMoles: 1.5
+    secPerMoles: 50
   - type: PowerSupplier
     supplyRate: 80000
   - type: Sprite


### PR DESCRIPTION
Хоть какая то мотивация их делать. Ну и фрезон варить тяжело очень.