### PR TITLE
Скрыть сломанный ген и источник рады из меню спавна

### DIFF
--- a/Resources/Prototypes/Adventure/Objects/Machines/NuclearGenerator/NuclearGenerator.yml
+++ b/Resources/Prototypes/Adventure/Objects/Machines/NuclearGenerator/NuclearGenerator.yml
@@ -176,6 +176,7 @@
 # источник радиации
 - type: entity
   id: RadiationSource
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
   - type: RadiationSource

--- a/Resources/Prototypes/Adventure/Objects/Machines/NuclearGenerator/NuclearGeneratorDestr.yml
+++ b/Resources/Prototypes/Adventure/Objects/Machines/NuclearGenerator/NuclearGeneratorDestr.yml
@@ -5,6 +5,7 @@
   name: ядерный генератор
   suffix: Сломанный НЕ СПАВНИТЬ
   description: Невероятно мощный генератор, излучающий радиоактивную энергию для длительного энергоснабжения.
+  categories: [ HideSpawnMenu ]
   components:
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
Чтобы больше не повторялось массовое убийство по неосторожности как в раунде 7321. Всё равно их спавнить смысла нет