### PR TITLE
Фикс трусов

### DIFF
--- a/Resources/Prototypes/Adventure/Races/IPC/Synth_inventory_template.yml
+++ b/Resources/Prototypes/Adventure/Races/IPC/Synth_inventory_template.yml
@@ -122,12 +122,12 @@
       slotFlags: BRASS
       stripTime: 3
       uiWindowPos: 3,2
-      strippingWindowPos: 2,1
+      strippingWindowPos: 3,1
       displayName: Brass
     - name: pants
       slotTexture: pants
       slotFlags: PANTS
       stripTime: 6
       uiWindowPos: 3,1
-      strippingWindowPos: 2,2
+      strippingWindowPos: 3,2
       displayName: Pants

--- a/Resources/Prototypes/Adventure/Races/Snake/Snake.yml
+++ b/Resources/Prototypes/Adventure/Races/Snake/Snake.yml
@@ -323,7 +323,7 @@
       slotFlags: BRASS
       stripTime: 3
       uiWindowPos: 3,2
-      strippingWindowPos: 2,1
+      strippingWindowPos: 3,1
       displayName: Brass
 
 - type: entity

--- a/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/arachnid_inventory_template.yml
@@ -87,14 +87,14 @@
       slotFlags: BRASS
       stripTime: 3
       uiWindowPos: 3,2
-      strippingWindowPos: 2,1
+      strippingWindowPos: 3,1
       displayName: Brass
     - name: pants
       slotTexture: pants
       slotFlags: PANTS
       stripTime: 6
       uiWindowPos: 3,1
-      strippingWindowPos: 2,2
+      strippingWindowPos: 3,2
       displayName: Pants
     # Adventure-slots-end
 

--- a/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/human_inventory_template.yml
@@ -127,13 +127,13 @@
       slotFlags: BRASS
       stripTime: 3
       uiWindowPos: 3,2
-      strippingWindowPos: 2,1
+      strippingWindowPos: 3,1
       displayName: Brass
     - name: pants
       slotTexture: pants
       slotFlags: PANTS
       stripTime: 6
       uiWindowPos: 3,1
-      strippingWindowPos: 2,2
+      strippingWindowPos: 3,2
       displayName: Pants
     # Adventure-slots-end


### PR DESCRIPTION
слоты нижнего белья, в меню обыска, были перенесены чуть правее основных, теперь они не мешают снимать перчатки, а чтобы их было видно меню нужно чуть расширить (теперь украсть трусы не так просто)