### PR TITLE
Батареи для КПБ

### DIFF
--- a/Content.Server/_Adventure/Races/IPC/IPCSystem.cs
+++ b/Content.Server/_Adventure/Races/IPC/IPCSystem.cs
@@ -1,0 +1,139 @@
+using Content.Server.PowerCell;
+using Content.Shared.Alert;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Systems;
+using Content.Shared.PowerCell;
+using Content.Shared.PowerCell.Components;
+using Robust.Shared.Player;
+using Content.Shared._Adventure.Races.IPC;
+
+namespace Content.Server._Adventure.Races.IPC;
+
+/// <summary>
+/// Код заимствован из BorgSystem с удалением всего лишнего.  
+/// В текущей версии компонент не имеет отличий от BorgSystem.
+/// </summary>
+public sealed partial class IPCSystem : SharedIPCSystem
+{
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
+    [Dependency] private readonly PowerCellSystem _powerCell = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<IPCComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<IPCComponent, MindAddedMessage>(OnMindAdded);
+        SubscribeLocalEvent<IPCComponent, MindRemovedMessage>(OnMindRemoved);
+        SubscribeLocalEvent<IPCComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<IPCComponent, PowerCellChangedEvent>(OnPowerCellChanged);
+        SubscribeLocalEvent<IPCComponent, PowerCellSlotEmptyEvent>(OnPowerCellSlotEmpty);
+        SubscribeLocalEvent<IPCComponent, GetCharactedDeadIcEvent>(OnGetDeadIC);
+        SubscribeLocalEvent<IPCComponent, ItemToggledEvent>(OnToggled);
+    }
+
+    private void OnMapInit(EntityUid uid, IPCComponent component, MapInitEvent args)
+    {
+        UpdateBatteryAlert((uid, component));
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(uid);
+    }
+
+    private void OnMindAdded(EntityUid uid, IPCComponent component, MindAddedMessage args)
+    {
+        IPCActivate(uid, component);
+    }
+
+    private void OnMindRemoved(EntityUid uid, IPCComponent component, MindRemovedMessage args)
+    {
+        IPCDeactivate(uid, component);
+    }
+
+    private void OnMobStateChanged(EntityUid uid, IPCComponent component, MobStateChangedEvent args)
+    {
+        if (args.NewMobState == MobState.Alive)
+        {
+            if (_mind.TryGetMind(uid, out _, out _))
+                _powerCell.SetDrawEnabled(uid, true);
+        }
+        else
+        {
+            _powerCell.SetDrawEnabled(uid, false);
+        }
+    }
+
+    private void OnPowerCellChanged(EntityUid uid, IPCComponent component, PowerCellChangedEvent args)
+    {
+        UpdateBatteryAlert((uid, component));
+
+        // if we aren't drawing and suddenly get enough power to draw again, reeanble.
+        if (_powerCell.HasDrawCharge(uid))
+        {
+            Toggle.TryActivate(uid);
+        }
+    }
+
+    private void OnPowerCellSlotEmpty(EntityUid uid, IPCComponent component, ref PowerCellSlotEmptyEvent args)
+    {
+        Toggle.TryDeactivate(uid);
+    }
+
+    private void OnGetDeadIC(EntityUid uid, IPCComponent component, ref GetCharactedDeadIcEvent args)
+    {
+        args.Dead = true;
+    }
+
+    private void OnToggled(Entity<IPCComponent> ent, ref ItemToggledEvent args)
+    {
+        var (uid, comp) = ent;
+        // only enable the powerdraw if there is a player in the chassis
+        var drawing = _mind.TryGetMind(uid, out _, out _) && _mobState.IsAlive(ent);
+        _powerCell.SetDrawEnabled(uid, drawing);
+
+        _movementSpeedModifier.RefreshMovementSpeedModifiers(uid);
+    }
+
+    private void UpdateBatteryAlert(Entity<IPCComponent> ent, PowerCellSlotComponent? slotComponent = null)
+    {
+        if (!_powerCell.TryGetBatteryFromSlot(ent, out var battery, slotComponent))
+        {
+            _alerts.ClearAlert(ent, ent.Comp.BatteryAlert);
+            _alerts.ShowAlert(ent, ent.Comp.NoBatteryAlert);
+            return;
+        }
+
+        var chargePercent = (short) MathF.Round(battery.CurrentCharge / battery.MaxCharge * 10f);
+
+        // we make sure 0 only shows if they have absolutely no battery.
+        // also account for floating point imprecision
+        if (chargePercent == 0 && _powerCell.HasDrawCharge(ent, cell: slotComponent))
+        {
+            chargePercent = 1;
+        }
+
+        _alerts.ClearAlert(ent, ent.Comp.NoBatteryAlert);
+        _alerts.ShowAlert(ent, ent.Comp.BatteryAlert, chargePercent);
+    }
+
+    public void IPCActivate(EntityUid uid, IPCComponent component)
+    {
+        if (_powerCell.HasDrawCharge(uid))
+        {
+            Toggle.TryActivate(uid);
+            _powerCell.SetDrawEnabled(uid, _mobState.IsAlive(uid));
+        }
+    }
+
+    public void IPCDeactivate(EntityUid uid, IPCComponent component)
+    {
+        Toggle.TryDeactivate(uid);
+        _powerCell.SetDrawEnabled(uid, false);
+    }
+}

--- a/Content.Server/_Adventure/Races/SnakeAccent/SnakeAccentComponent.cs
+++ b/Content.Server/_Adventure/Races/SnakeAccent/SnakeAccentComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Server._Adventure.SnakeAccent;
+namespace Content.Server._Adventure.Races.SnakeAccent;
 
 /// <summary>
 ///     Rrrr!

--- a/Content.Server/_Adventure/Races/SnakeAccent/SnakeAccentSystem.cs
+++ b/Content.Server/_Adventure/Races/SnakeAccent/SnakeAccentSystem.cs
@@ -1,8 +1,8 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using Content.Server.Speech;
 using Robust.Shared.Random;
 
-namespace Content.Server._Adventure.SnakeAccent;
+namespace Content.Server._Adventure.Races.SnakeAccent;
 
 public sealed class SnakeAccentSystem : EntitySystem
 {

--- a/Content.Shared/_Adventure/Races/IPC/IPCComponent.cs
+++ b/Content.Shared/_Adventure/Races/IPC/IPCComponent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Alert;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Adventure.Races.IPC;
+
+/// <summary>
+/// Код заимствован из BorgChassisComponent с удалением всего лишнего.  
+/// В текущей версии компонент не имеет отличий от BorgChassisComponent.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedIPCSystem))]
+public sealed partial class IPCComponent : Component
+{
+    [DataField]
+    public ProtoId<AlertPrototype> BatteryAlert = "IPCBattery";
+
+    [DataField]
+    public ProtoId<AlertPrototype> NoBatteryAlert = "BorgBatteryNone";
+}

--- a/Content.Shared/_Adventure/Races/IPC/SharedIPCSystem.cs
+++ b/Content.Shared/_Adventure/Races/IPC/SharedIPCSystem.cs
@@ -1,0 +1,54 @@
+using Content.Shared.IdentityManagement;
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared._Adventure.Races.IPC;
+
+/// <summary>
+/// This handles logic, interactions, and UI related to <see cref="IPCComponent"/> and other related components.
+/// Код заимствован из SharedBorgSystem с удалением всего лишнего.  
+/// В текущей версии компонент не имеет отличий от SharedBorgSystem.
+/// </summary>
+public abstract partial class SharedIPCSystem : EntitySystem
+{
+    [Dependency] protected readonly ItemToggleSystem Toggle = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+
+        SubscribeLocalEvent<IPCComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeedModifiers);
+        SubscribeLocalEvent<TryGetIdentityShortInfoEvent>(OnTryGetIdentityShortInfo);
+    }
+
+    private void OnTryGetIdentityShortInfo(TryGetIdentityShortInfoEvent args)
+    {
+        if (args.Handled)
+        {
+            return;
+        }
+
+        if (!HasComp<IPCComponent>(args.ForActor))
+        {
+            return;
+        }
+
+        args.Title = Name(args.ForActor).Trim();
+        args.Handled = true;
+    }
+
+    private void OnRefreshMovementSpeedModifiers(EntityUid uid, IPCComponent component, RefreshMovementSpeedModifiersEvent args)
+    {
+        if (Toggle.IsActivated(uid))
+            return;
+
+        if (!TryComp<MovementSpeedModifierComponent>(uid, out var movement))
+            return;
+
+        var sprintDif = movement.BaseWalkSpeed / movement.BaseSprintSpeed;
+        args.ModifySpeed(1f, sprintDif);
+    }
+}

--- a/Resources/Locale/ru-RU/alerts/alerts.ftl
+++ b/Resources/Locale/ru-RU/alerts/alerts.ftl
@@ -74,3 +74,6 @@ alerts-revenant-essence-name = Эссенция
 alerts-revenant-essence-desc = Сила душ. Поддерживает вас и используется при использовании способностей. Медленно восстанавливается с течением времени.
 alerts-revenant-corporeal-name = Материальность
 alerts-revenant-corporeal-desc = Вы физически воплотились. Окружающие могут видеть и наносить вам вред.
+
+alerts-ipc-battery-name = Батарея
+alerts-ipc-battery-desc = Если батарея разрядится, ваша скорость передвижения снизится.

--- a/Resources/Prototypes/Adventure/Races/IPC/Synth.yml
+++ b/Resources/Prototypes/Adventure/Races/IPC/Synth.yml
@@ -183,6 +183,9 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalSlam
+      - !type:EmptyContainersBehaviour
+        containers:
+        - cell_slot
   - type: SlowOnDamage
     speedModifierThresholds:
       60: 0.9
@@ -229,6 +232,25 @@
   - type: GuideHelp
     guides:
     - Species
+  - type: ContainerContainer
+    containers:
+      cell_slot: !type:ContainerSlot { }
+  - type: PowerCellSlot
+    cellSlotId: cell_slot
+    fitsInCharger: true
+  - type: PowerCellDraw
+    drawRate: 10
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellSmall
+        locked: true
+  - type: ItemToggle
+    onActivate: false
+    activated: false
+    onUse: false
+  - type: IPC
 
 - type: entity
   parent: BaseSpeciesDummy
@@ -237,3 +259,35 @@
   components:
     - type: HumanoidAppearance
       species: Synth
+
+# Alerts:
+- type: alert
+  id: IPCBattery
+  category: Battery
+  icons:
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery0
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery1
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery2
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery3
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery4
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery5
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery6
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery7
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery8
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery9
+  - sprite: /Textures/Interface/Alerts/battery.rsi
+    state: battery10
+  name: alerts-ipc-battery-name
+  description: alerts-ipc-battery-desc
+  minSeverity: 0
+  maxSeverity: 10

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -245,6 +245,7 @@
     whitelist:
       components:
       - BorgChassis
+      - IPC
   - type: Construction
     containers:
     - machine_parts
@@ -288,6 +289,7 @@
     whitelist:
       components:
       - BorgChassis
+      - IPC
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container


### PR DESCRIPTION
_**Draft**_

## Описание PR
КПБ получили батареи! Теперь им необходимо периодически подзаряжаться в зарядных станциях — иначе скорость передвижения снизится, а зрение ухудшится.

## Зачем?
По сути, батареи для КПБ — это аналог голода у органических существ.

## Медиа
https://discord.com/channels/1163557601838121022/1164546797155397714/1340801348794322955

## Планы:
- [ ] Сделать так, чтобы КПБ слепли при разряде батареи.
- [ ] Исправить мелкие недочеты (из КПБ не выпадает батарейка при гиббе)
- [ ] Правильно настроить потребление энергии батареей КПБ, чтобы она разряжалась чуть быстрее, чем люди достигают финальной стадии голода.

## Технические детали
Добавлен компонент и системы IPC, заимствованные из BorgSystem. Оригинальный BorgSystem использовать не удалось из-за ошибок в консоли, связанных с отсутствием необходимых спрайтов для корректной работы системы.

## Изменения
:cl:
- tweak: КПБ получили батареи! Теперь им необходимо периодически подзаряжаться в зарядных станциях — иначе скорость передвижения снизится, а зрение ухудшится.