### PR TITLE
расисты из НаноТрахен

### DIFF
--- a/Resources/Locale/ru-RU/job/role-requirements.ftl
+++ b/Resources/Locale/ru-RU/job/role-requirements.ftl
@@ -4,8 +4,8 @@ role-timer-overall-insufficient = Требуется ещё [color=yellow]{ TOST
 role-timer-overall-too-high = Требуется на [color=yellow]{ TOSTRING($time, "0") }[/color] меньше минут общего игрового времени. (Вы пытаетесь играть за роль для новичков?)
 role-timer-role-insufficient = Требуется ещё [color=yellow]{ TOSTRING($time, "0") }[/color] минут игры в качестве [color={ $departmentColor }]{ $job }[/color] для этой роли.
 role-timer-role-too-high = Требуется на [color=yellow]{ TOSTRING($time, "0") }[/color] меньше минут игры в качестве [color={ $departmentColor }]{ $job }[/color] для этой роли. (Вы пытаетесь играть за роль для новичков?)
-role-timer-age-to-old = Возраст персонажа должен быть не более [color=yellow]{ $age }[/color] для этой роли.
-role-timer-age-to-young = Возраст персонажа должен быть не менее [color=yellow]{ $age }[/color] для этой роли.
+role-timer-age-too-old = Возраст персонажа должен быть не более [color=yellow]{ $age }[/color] для этой роли.
+role-timer-age-too-young = Возраст персонажа должен быть не менее [color=yellow]{ $age }[/color] для этой роли.
 role-timer-whitelisted-species = Ваш персонаж должен быть одной из следующих рас для этой роли:
 role-timer-blacklisted-species = Ваш персонаж не должен быть одной из следующих рас для этой роли:
 role-timer-whitelisted-traits = Ваш персонаж должен иметь одну из следующих черт:

--- a/Resources/Prototypes/Adventure/Roles/blueshield/blueshield.yml
+++ b/Resources/Prototypes/Adventure/Roles/blueshield/blueshield.yml
@@ -18,6 +18,15 @@
       time: 7200 # 2 hours
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   startingGear: BlueshieldGear
   icon: "JobIconBlueshield"
   requireAdminNotify: true

--- a/Resources/Prototypes/Adventure/Roles/brigmed/brigmed.yml
+++ b/Resources/Prototypes/Adventure/Roles/brigmed/brigmed.yml
@@ -19,6 +19,12 @@
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 3600 #1 hrs
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - PigMan
+# Adventure-edit-end
   startingGear: BrigmedicGearADVENT
   icon: "JobIconBrigmedic"
   requireAdminNotify: true

--- a/Resources/Prototypes/Corvax/Roles/Jobs/Command/iaa.yml
+++ b/Resources/Prototypes/Corvax/Roles/Jobs/Command/iaa.yml
@@ -12,6 +12,15 @@
     time: 36000
   - !type:AgeRequirement
     requiredAge: 30 # Adventure
+# Adventure-edit-start
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Synth
+    - Zerah
+    - PigMan
+    - Vox
+# Adventure-edit-end
   startingGear: IAAGear
   icon: "JobIconIAA"
   supervisors: job-supervisors-centcom

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -7,6 +7,12 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 36000 #10 hrs # Adventure
+# Adventure-edit-start
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Synth
+# Adventure-edit-end
   guides: [ Zombies ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -17,6 +17,15 @@
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -29,6 +29,15 @@
       time: 36000 #10 hours # Adventure
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -29,6 +29,15 @@
       time: 18000 #5 hours # Adventure
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -17,6 +17,15 @@
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -19,6 +19,15 @@
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -11,6 +11,15 @@
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -7,6 +7,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10 hours # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - PigMan
+# Adventure-edit-end
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -17,6 +17,15 @@
 #      time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 30 # Adventure
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Synth
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -7,6 +7,14 @@
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 36000 #10 hrs
+# Adventure-edit-start
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Zerah
+      - PigMan
+      - Vox
+# Adventure-edit-end
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
1. КПБ, зерахи, троттины и воксы больше не могут быть КМД
2. зерахи, троттины и воксы теперь ограничены в ролях СБ

я забыл как поставить расу в блэклист на спавнеры ОБР и тд, поэтому тут их нет, увы