### PR TITLE
Бомж в спокойный режим

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -39,7 +39,6 @@
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
     - id: DerelictCyborgSpawn
-    - id: HoboSpawn # Adventure
     - id: WizardSpawn
     - id: HungerSwarmInvasion # Adventure
 

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -20,6 +20,7 @@
     - id: UnknownShuttleMeatZone
     - id: UnknownShuttleMicroshuttle
     - id: UnknownShuttleSpacebus
+    - id: HoboSpawn # Adventure
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable


### PR DESCRIPTION
Перенёс бомжа из антагов в "дружественные шаттлы". Не вижу причин не появляться бомжаре в гриншифт и спокойный, он не антаг в общем-то