### PR TITLE
Осветительный набор

### DIFF
--- a/Resources/Prototypes/Adventure/Objects/Specific/lightpack.yml
+++ b/Resources/Prototypes/Adventure/Objects/Specific/lightpack.yml
@@ -1,0 +1,24 @@
+- type: entity
+  id: CrateEmergencyFlarePack
+  parent: CrateGenericSteel
+  name: ящик фальшфейеров
+  description: Содержит 2 набора для временного освещения территории.
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxFlare
+        amount: 2
+      - id: BoxShotgunFlare
+        amount: 2
+      - id: WeaponFlareGun
+        amount: 2
+
+- type: cargoProduct
+  id: EmergencyFlare
+  icon:
+    sprite: Objects/Misc/flare.rsi
+    state: icon
+  product: CrateEmergencyFlarePack
+  cost: 1500
+  category: cargoproduct-category-name-emergency
+  group: market

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -34,6 +34,7 @@
   id: SecurityAmmoStatic
   recipes:
   - BoxLethalshot
+  - BoxShotgunFlare # Adventure
   - BoxShotgunSlug
   - MagazineBoxLightRifle
   - MagazineBoxMagnum


### PR DESCRIPTION
Добавлен новый товар в карго "ящик фальшфейеров", стоит 1500, содержит 2 набора для освещения: пистоль, раздатчик патронов, коробка фальшфейеров.
~Вернул в статик пак техфаба раздатчик фальшфейеров, хз почему его там не было.~ Окей, я нашёл причину, если этим начнут спаммить, будет удалено.
Идея Котулы.