### PR TITLE
Нуарные очки #2

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -290,6 +290,12 @@
     sprite: Clothing/Eyes/Glasses/noir.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/sunglasses.rsi
+  - type: ShowJobIcons #Adventure
+  - type: ShowMindShieldIcons #Adventure
+  - type: ShowCriminalRecordIcons #Adventure
+  - type: Construction #Adventure
+    graph: GlassesSecHUD #Adventure
+    node: glassesSec #Adventure
   - type: IdentityBlocker
     coverage: EYES
   - type: FlashImmunity


### PR DESCRIPTION
Добавляет для удобства детективам, нуарным очкам дополнительно те же свойства, что и у визорных очков охраны.

И специально для ранимого борка, я проследил чтобы был добавлен тэг Эдвенчура, ведь кроме меня, никто не смог бы это сделать