### PR TITLE
Создание латуни

### DIFF
--- a/Resources/Prototypes/Adventure/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Adventure/Recipes/Reactions/fun.yml
@@ -1,0 +1,13 @@
+- type: reaction
+  id: SheetBrass
+  impact: Low
+  quantized: true
+  minTemp: 720
+  reactants:
+    Copper:
+      amount: 7
+    Zinc:
+      amount: 3
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: SheetBrass1


### PR DESCRIPTION
Химик может создать 1 единицу латуни, для этого нужно: 7 Меди, 3 Цинка, нагреть до 720 градусов.

По балансу вроде сойдет, 1 единица перерабатывается в 6,7 меди и 3,3 цинка. 