### PR TITLE
Фиксы

### DIFF
--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Humanoid;
+using Content.Shared._Adventure.TTS; // Adventure TTS fix
 using Content.Shared.Administration.Logs;
 using Content.Shared.Cloning;
 using Content.Shared.Cloning.Events;
@@ -133,6 +134,14 @@ public sealed partial class CloningSystem : EntitySystem
 
         var cloningEv = new CloningEvent(settings, clone);
         RaiseLocalEvent(original, ref cloningEv); // used for datafields that cannot be directly copied using CopyComp
+
+        // Adventure TTS fix start
+        if (TryComp<TTSComponent>(original, out var originalTTS))
+        {
+            var cloneTTS = EnsureComp<TTSComponent>(clone);
+            cloneTTS.VoicePrototypeId = originalTTS.VoicePrototypeId;
+        }
+        // Adventure TTS fix end
     }
 
     /// <summary>

--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -3,7 +3,6 @@ using Content.Server.Cloning;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Medical.SuitSensors;
 using Content.Server.Objectives.Components;
-using Content.Shared._Adventure.TTS; // Adventure TTS fix
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Medical.SuitSensor;
@@ -93,16 +92,6 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         _sensor.SetAllSensors(clone.Value, SuitSensorMode.SensorOff);
 
         args.Entity = clone;
-        // Adventure TTS fix start
-        if (ent.Comp.OriginalBody != null && clone != null)
-        {
-            if (TryComp<TTSComponent>(ent.Comp.OriginalBody.Value, out var originalTTS))
-            {
-                var cloneTTS = EnsureComp<TTSComponent>(clone.Value);
-                cloneTTS.VoicePrototypeId = originalTTS.VoicePrototypeId;
-            }
-        }
-        // Adventure TTS fix end
     }
 
     private void AfterAntagEntitySelected(Entity<ParadoxCloneRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)

--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -3,7 +3,7 @@ using Content.Server.Cloning;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Medical.SuitSensors;
 using Content.Server.Objectives.Components;
-using Content.Shared._Adventure.TTS; // Adventure tts fix
+using Content.Shared._Adventure.TTS; // Adventure TTS fix
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Medical.SuitSensor;
@@ -93,7 +93,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         _sensor.SetAllSensors(clone.Value, SuitSensorMode.SensorOff);
 
         args.Entity = clone;
-
+        // Adventure TTS fix start
         if (ent.Comp.OriginalBody != null && clone != null)
         {
             if (TryComp<TTSComponent>(ent.Comp.OriginalBody.Value, out var originalTTS))
@@ -102,6 +102,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
                 cloneTTS.VoicePrototypeId = originalTTS.VoicePrototypeId;
             }
         }
+        // Adventure TTS fix end
     }
 
     private void AfterAntagEntitySelected(Entity<ParadoxCloneRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)

--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Cloning;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Medical.SuitSensors;
 using Content.Server.Objectives.Components;
+using Content.Shared._Adventure.TTS; // Adventure tts fix
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Medical.SuitSensor;
@@ -92,6 +93,15 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
         _sensor.SetAllSensors(clone.Value, SuitSensorMode.SensorOff);
 
         args.Entity = clone;
+
+        if (ent.Comp.OriginalBody != null && clone != null)
+        {
+            if (TryComp<TTSComponent>(ent.Comp.OriginalBody.Value, out var originalTTS))
+            {
+                var cloneTTS = EnsureComp<TTSComponent>(clone.Value);
+                cloneTTS.VoicePrototypeId = originalTTS.VoicePrototypeId;
+            }
+        }
     }
 
     private void AfterAntagEntitySelected(Entity<ParadoxCloneRuleComponent> ent, ref AfterAntagEntitySelectedEvent args)

--- a/Content.Shared/Labels/Components/HandLabelerComponent.cs
+++ b/Content.Shared/Labels/Components/HandLabelerComponent.cs
@@ -19,6 +19,9 @@ public sealed partial class HandLabelerComponent : Component
 
     [DataField]
     public EntityWhitelist Whitelist = new();
+
+    [DataField]
+    public EntityWhitelist Blacklist = new(); // Adventure races
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -79,7 +79,10 @@ public abstract class SharedHandLabelerSystem : EntitySystem
 
     private void OnUtilityVerb(EntityUid uid, HandLabelerComponent handLabeler, GetVerbsEvent<UtilityVerb> args)
     {
-        if (args.Target is not { Valid: true } target || _whitelistSystem.IsWhitelistFail(handLabeler.Whitelist, target) || !args.CanAccess)
+        if (args.Target is not { Valid: true } target // Adventure races start
+            || _whitelistSystem.IsWhitelistFail(handLabeler.Whitelist, target)
+            || _whitelistSystem.IsBlacklistPass(handLabeler.Blacklist, target)
+            || !args.CanAccess) // Adventure races end
             return;
 
         var labelerText = handLabeler.AssignedLabel == string.Empty ? Loc.GetString("hand-labeler-remove-label-text") : Loc.GetString("hand-labeler-add-label-text");
@@ -98,7 +101,10 @@ public abstract class SharedHandLabelerSystem : EntitySystem
 
     private void AfterInteractOn(EntityUid uid, HandLabelerComponent handLabeler, AfterInteractEvent args)
     {
-        if (args.Target is not { Valid: true } target || _whitelistSystem.IsWhitelistFail(handLabeler.Whitelist, target) || !args.CanReach)
+        if (args.Target is not { Valid: true } target // Adventure races start
+            || _whitelistSystem.IsWhitelistFail(handLabeler.Whitelist, target)
+            || _whitelistSystem.IsBlacklistPass(handLabeler.Blacklist, target)
+            || !args.CanReach) // Adventure races end
             return;
 
         Labeling(uid, target, args.User, handLabeler);

--- a/Resources/Locale/ru-RU/corvax/accent/cowboy.ftl
+++ b/Resources/Locale/ru-RU/corvax/accent/cowboy.ftl
@@ -10,7 +10,6 @@ corvax-accent-cowboy-replacement-4 = благодарствую
 corvax-accent-cowboy-words-501 = привет
 corvax-accent-cowboy-words-502 = здравствуй
 corvax-accent-cowboy-replacement-5 = хауди
-corvax-accent-cowboy-words-601 = пока
 corvax-accent-cowboy-words-602 = прощай
 corvax-accent-cowboy-replacement-6 = бывай
 corvax-accent-cowboy-words-7 = до свидания

--- a/Resources/Locale/ru-RU/random-metadata/random-metadata-formats.ftl
+++ b/Resources/Locale/ru-RU/random-metadata/random-metadata-formats.ftl
@@ -6,7 +6,7 @@ name-format-regal-rat = { $part0 } { $part1 }
 name-format-revenant = { $part0 } { $part1 } { $part2 }
 name-format-ninja = { $part0 } { $part1 }
 name-format-wizard = { $part0 } { $part1 }
-name-format-dragon = { $part1 } { $part0 }
+name-format-dragon = { $part0 } { $part1 }
 # "<title> <name>"
 name-format-nukie-generic = { $part0 } { $part1 }
 name-format-nukie-agent = Агент { $part0 }

--- a/Resources/Locale/ru-RU/robust-toolbox/view-variables.ftl
+++ b/Resources/Locale/ru-RU/robust-toolbox/view-variables.ftl
@@ -1,5 +1,6 @@
 ## ViewVariablesInstanceEntity
 
+view-variables = Просмотр Переменных
 view-variable-instance-entity-server-components-add-component-button-placeholder = Добавить компонент
 view-variable-instance-entity-client-variables-tab-title = Переменные клиента
 view-variable-instance-entity-client-components-tab-title = Компоненты клиента
@@ -7,5 +8,19 @@ view-variable-instance-entity-server-variables-tab-title = Переменные 
 view-variable-instance-entity-server-components-tab-title = Компоненты сервера
 view-variable-instance-entity-client-components-search-bar-placeholder = Поиск
 view-variable-instance-entity-server-components-search-bar-placeholder = Поиск
-view-variable-instance-entity-add-window-server-components = Добавить компонент [Сервер]
-view-variable-instance-entity-add-window-client-components = Добавить компонен [Клиент]
+view-variable-instance-entity-add-window-server-components = Добавить компонент [С]
+view-variable-instance-entity-add-window-client-components = Добавить компонент [К]
+
+## SoundSpecifier
+vv-sound-none = Нет
+vv-sound-path = Путь
+vv-sound-collection = Коллекция
+
+vv-sound-volume = Громкость
+vv-sound-pitch = Тон
+vv-sound-max-distance = Максимальная дистанция
+vv-sound-rolloff-factor = Коэффициент затухания
+vv-sound-reference-distance = Опорная дистанция
+vv-sound-loop = Зациклить
+vv-sound-play-offset = Смещение воспроизведения (с)
+vv-sound-variation = Вариация тона

--- a/Resources/Prototypes/Adventure/Objects/Machines/NuclearGenerator/NuclearGenerator.yml
+++ b/Resources/Prototypes/Adventure/Objects/Machines/NuclearGenerator/NuclearGenerator.yml
@@ -136,6 +136,9 @@
         Cable: 10
         Uranium: 30
         NukeActivator: 1
+    - type: Tag
+      tags:
+        - NukeGenerator
 
 - type: latheRecipe
   id: NuclearGeneratorMachineCircuitboard
@@ -199,6 +202,9 @@
 
 - type: Tag
   id: NukeActivator
+
+- type: Tag
+  id: NukeGenerator
 
 - type: stack
   id: NukeActivator

--- a/Resources/Prototypes/Adventure/Objects/Machines/Printer/printer.yml
+++ b/Resources/Prototypes/Adventure/Objects/Machines/Printer/printer.yml
@@ -26,6 +26,8 @@
     #   map: ["enum.MaterialStorageVisualLayers.Inserting"]
   - type: MaterialStorage
     useInsertingAnimation: false
+    canEjectStoredMaterials: false
+    dropOnDeconstruct: false
     whitelist:
       tags:
         - Document

--- a/Resources/Prototypes/Adventure/Races/Resomi/Resomi.yml
+++ b/Resources/Prototypes/Adventure/Races/Resomi/Resomi.yml
@@ -21,6 +21,9 @@
   parent: BaseMobResomi
   id: MobResomi
 
+- type: Tag
+  id: InHandsMob
+
 - type: entity
   abstract: true
   save: false
@@ -47,6 +50,9 @@
     scale: 0.8, 0.8
   - type: Item
     size: Ginormous
+  - type: Tag
+    tags:
+      - InHandsMob
   - type: MultiHandedItem
   - type: CanEscapeInventory # надо
   - type: Bloodstream
@@ -73,18 +79,18 @@
     heatDamageThreshold: 298.15 # 25с - начинаем получать урон.
     coldDamageThreshold: 213
     currentTemperature: 291.15 # температура 20с = стандартной атмосферной на станции (+-). Модификаторы на изменения температуры описаны ниже.
-    coldDamage: 
+    coldDamage:
       types:
         Cold : 0.1
     specificHeat: 42
-    heatDamage: 
+    heatDamage:
       types:
         Heat : 1.5
   - type: TemperatureSpeed # так как данный компонент не расчитан на установку понижения скокрости от жары, то первая строчка установлена на невозможную температуру тела.
     thresholds:
       10273: 0.4 # *невозможное число* (чтобы резоми резко не ускорялся при темпе выше 25с,а продолжал ходить медленно).
-      298: 0.7 
-      295: 0.9 # с этого значения и до невозможного числа резоми теряет скорость от жары. 
+      298: 0.7
+      295: 0.9 # с этого значения и до невозможного числа резоми теряет скорость от жары.
       294: 1.0 # так как пороги скорости работают от верхнего числа к нижнему, порог от 294 до 275кпа нужен, чтобы имел свою нормальную скорость в комфортных условиях.
       275.15: 1.1 # отсюда и до 225 резоми получает 10% буста к скорости, потому что ему кайф.
       225: 0.9 # отсюда резоми начинает терять скорость, чтоб не втыкал.
@@ -97,10 +103,11 @@
     prototype: Resomi
     requiredLegs: 2
   - type: Hunger
-  - type: Icon 
+  - type: Icon
     sprite: Adventure/Races/Resomi/Species/parts.rsi
     state: full
   - type: Thirst
+
   - type: Butcherable
     butcheringType: Spike
     spawned:
@@ -112,7 +119,7 @@
     - HeadTop
     - Hair
   - type: Fixtures
-    fixtures: 
+    fixtures:
       fix1:
         shape:
           !type:PhysShapeCircle

--- a/Resources/Prototypes/Adventure/Races/Resomi/Resomi.yml
+++ b/Resources/Prototypes/Adventure/Races/Resomi/Resomi.yml
@@ -53,6 +53,10 @@
   - type: Tag
     tags:
       - InHandsMob
+      - CanPilot
+      - FootstepSound
+      - DoorBumpOpener
+      - AnomalyHost
   - type: MultiHandedItem
   - type: CanEscapeInventory # надо
   - type: Bloodstream

--- a/Resources/Prototypes/Corvax/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -40,3 +40,5 @@
         Shock: 0.1
         Cold: 0.2
         Radiation: 0.2
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.75

--- a/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Corvax/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -31,3 +31,5 @@
     damageCoefficient: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetCBURNLeader
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.01

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -25,4 +25,7 @@
           - Item
         tags:
           - Structure
+      blacklist:
+        tags:
+          - InHandsMob
     - type: PhysicalComposition

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -69,6 +69,12 @@
           components:
           - MachineBoard
           - ComputerBoard
+# Adventure Nuke start
+        blacklist:
+          tags:
+          - NukeGenerator
+# Adventure Nuke end
+
   - type: ContainerContainer
     containers:
       machine_board: !type:Container


### PR DESCRIPTION
1) Исправил перенос ТТСа на клона.
2) Скаф лидера РХБЗЗ теперь защищает от заражения, на целых 99%, они итак бомжи, так хоть чуть защищённее будут.
3) Больше нельзя достать бумагу из принтера, как и перерабатывать её так в материал.
4) Больше нельзя бесконечно строить ядерный генераторы, как и упаковать его в целом.
5) Исправлено отображение имени дракона.
6) Больше ковбойский акцент не заменяет `пока` на `бывай`.
7) Этикетировщику добавлена поддержка чёрного списка.
  7.1. Благодаря прошлому изменению, теперь этикетки  нельзя клеить на Резоми.