### PR TITLE
Попытка фикса спавна в коморке БМа

### DIFF
--- a/Resources/Maps/_Adventure/Adventureamber.yml
+++ b/Resources/Maps/_Adventure/Adventureamber.yml
@@ -138217,7 +138217,7 @@ entities:
     - type: Transform
       pos: -16.5,-33.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 20329
     components:

--- a/Resources/Maps/_Adventure/Adventurebagel.yml
+++ b/Resources/Maps/_Adventure/Adventurebagel.yml
@@ -134561,7 +134561,7 @@ entities:
     - type: Transform
       pos: 34.5,-36.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 20533
     components:

--- a/Resources/Maps/_Adventure/Adventuremaus.yml
+++ b/Resources/Maps/_Adventure/Adventuremaus.yml
@@ -112410,7 +112410,7 @@ entities:
     - type: Transform
       pos: -42.5,-26.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 14119
     components:

--- a/Resources/Maps/_Adventure/Adventureomega.yml
+++ b/Resources/Maps/_Adventure/Adventureomega.yml
@@ -74795,7 +74795,7 @@ entities:
     - type: Transform
       pos: -13.5,-6.5
       parent: 4812
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 7787
     components:

--- a/Resources/Maps/_Adventure/Adventurepacked.yml
+++ b/Resources/Maps/_Adventure/Adventurepacked.yml
@@ -85975,7 +85975,7 @@ entities:
     - type: Transform
       pos: 44.5,-6.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 15684
     components:

--- a/Resources/Maps/_Adventure/Adventurepebble.yml
+++ b/Resources/Maps/_Adventure/Adventurepebble.yml
@@ -64633,7 +64633,7 @@ entities:
     - type: Transform
       pos: -5.5,8.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 9554
     components:

--- a/Resources/Maps/_Adventure/Adventureplasma.yml
+++ b/Resources/Maps/_Adventure/Adventureplasma.yml
@@ -142947,7 +142947,7 @@ entities:
     - type: Transform
       pos: -46.5,-23.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 16289
     components:

--- a/Resources/Maps/_Adventure/Adventuresilly.yml
+++ b/Resources/Maps/_Adventure/Adventuresilly.yml
@@ -49862,7 +49862,7 @@ entities:
     - type: Transform
       pos: 15.5,-14.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 5657
     components:

--- a/Resources/Maps/_Adventure/Adventuretrain.yml
+++ b/Resources/Maps/_Adventure/Adventuretrain.yml
@@ -90212,7 +90212,7 @@ entities:
     - type: Transform
       pos: -6.5,-84.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 13671
     components:

--- a/Resources/Maps/_Adventure/Polaris.yml
+++ b/Resources/Maps/_Adventure/Polaris.yml
@@ -77913,7 +77913,7 @@ entities:
     - type: Transform
       pos: -32.5,-9.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 11683
     components:

--- a/Resources/Maps/_Adventure/Shipyard.yml
+++ b/Resources/Maps/_Adventure/Shipyard.yml
@@ -79981,7 +79981,7 @@ entities:
     - type: Transform
       pos: 15.5,26.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 13518
     components:

--- a/Resources/Maps/_Adventure/Star.yml
+++ b/Resources/Maps/_Adventure/Star.yml
@@ -97326,7 +97326,7 @@ entities:
     - type: Transform
       pos: 31.5,14.5
       parent: 2
-- proto: SpawnPointBrigmedic
+- proto: SpawnPointBrigmedicAdven
   entities:
   - uid: 13886
     components:

--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -485,15 +485,16 @@
       - state: green
       - state: detective
 
-- type: entity
-  id: SpawnPointBrigmedic
-  parent: SpawnPointJobBase
-  name: brigmedic
-  components:
-  - type: Sprite
-    layers:
-      - state: green
-      - state: brigmedic
+# ADV: Removed cuz SpawnPointBrigmedicAdven exists
+# - type: entity
+#   id: SpawnPointBrigmedic
+#   parent: SpawnPointJobBase
+#   name: brigmedic
+#   components:
+#   - type: Sprite
+#     layers:
+#       - state: green
+#       - state: brigmedic
 
 # SPECIAL
 # ERT


### PR DESCRIPTION
По какой-то причине, у визов спавнпоинт БМа не ссылается ни на какую роль, поэтому там может спавниться кто захочет...по всей видимости поэтому там любят спавниться все те, кто прожали "готово" раундстартом. 